### PR TITLE
Add new Newcastle and London pools to Leaflet map

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,7 +405,15 @@ const LogoWordmark = ({ size = "lg" }) => {
             {name:'Glasgow Club Maryhill',city:'Glasgow',lat:55.8934,lng:-4.2934},
             {name:'The PEAK',city:'Stirling',lat:56.1123,lng:-3.9234},
             {name:'Zwembad De Zijl',city:'Leiden',lat:52.1734,lng:4.4589},
-            {name:'Combibad De Vliet',city:'Leiden',lat:52.1823,lng:4.4234}
+            {name:'Combibad De Vliet',city:'Leiden',lat:52.1823,lng:4.4234},
+            {name:'Jesmond Pool & Gym',city:'Newcastle',lat:54.9879,lng:-1.6028},
+            {name:'East End Pool',city:'Newcastle',lat:54.9760,lng:-1.5659},
+            {name:'Gosforth Leisure Centre',city:'Newcastle',lat:55.0116,lng:-1.6209},
+            {name:'City Baths Newcastle',city:'Newcastle',lat:54.9780,lng:-1.6078},
+            {name:'London Aquatics Centre',city:'London',lat:51.5386,lng:-0.0166},
+            {name:'Porchester Leisure Centre',city:'London',lat:51.5162,lng:-0.1909},
+            {name:'Marshall Street Leisure Centre',city:'London',lat:51.5133,lng:-0.1378},
+            {name:'Dulwich Leisure Centre',city:'London',lat:51.4548,lng:-0.0734}
           ];
           pools.forEach(p => {
             window.L.circleMarker([p.lat, p.lng], {


### PR DESCRIPTION
### Motivation
- Keep the interactive Leaflet map in `index.html` aligned with the expanded pool catalog by adding the new pool locations so they appear as markers on the map.

### Description
- Updated the `pools` array in `index.html` to include additional pool entries for Newcastle and London.
- Added markers for `Jesmond Pool & Gym`, `East End Pool`, `Gosforth Leisure Centre`, and `City Baths Newcastle` in Newcastle and `London Aquatics Centre`, `Porchester Leisure Centre`, `Marshall Street Leisure Centre`, and `Dulwich Leisure Centre` in London.
- Left the existing marker rendering code unchanged so the new entries automatically use the existing `L.circleMarker` styling and popup behavior.

### Testing
- Verified the changes with `git diff -- index.html` to confirm the new markers were added and no unrelated files changed, which succeeded.
- Committed the updated file with `git commit` and inspected the resulting lines with `nl -ba index.html | sed -n '396,424p'` to confirm the inserted entries, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0bad6be8832686e431022df66e5d)