### PR TITLE
Add cascading Country > State > City filters to main list and check-in

### DIFF
--- a/pool-busyness-tracker.jsx
+++ b/pool-busyness-tracker.jsx
@@ -448,7 +448,9 @@ const BUSYNESS_LEVELS = [
 export default function PoolBusynessTracker() {
   const appLogo = './assets/poolpulse_app_icon_color.svg';
   const [poolData, setPoolData] = useState({});
-  const [selectedRegion, setSelectedRegion] = useState('Scotland');
+  const [selectedCountry, setSelectedCountry] = useState('UK');
+  const [selectedState, setSelectedState] = useState('Scotland');
+  const [selectedCity, setSelectedCity] = useState('All cities');
   const [selectedPool, setSelectedPool] = useState(null);
   const [selectedLane, setSelectedLane] = useState(null);
   const [selectedBusyness, setSelectedBusyness] = useState(null);
@@ -583,21 +585,49 @@ export default function PoolBusynessTracker() {
     return city === 'Leiden' ? `${city} 🇳🇱` : city;
   };
 
-  const getRegionForPool = (pool) => {
+  const getPoolCountry = (pool) => {
+    if ((pool.country || '').toUpperCase() === 'NL') return 'Netherlands';
+    if ((pool.country || '').toUpperCase() === 'UK') return 'UK';
     const city = getPoolCity(pool).toLowerCase();
+    return city === 'leiden' ? 'Netherlands' : 'UK';
+  };
 
-    if (city === 'leiden') return 'The Netherlands';
+  const getPoolState = (pool) => {
+    const country = getPoolCountry(pool);
+    if (country === 'Netherlands') return 'South Holland';
+    const city = getPoolCity(pool);
+    if (city === 'London') return 'England';
     return 'Scotland';
   };
 
-  const filteredPools = POOLS.filter(pool => getRegionForPool(pool) === selectedRegion);
+  const availableStates = Array.from(new Set(POOLS.filter(pool => getPoolCountry(pool) === selectedCountry).map(getPoolState)));
+  const availableCities = Array.from(new Set(POOLS.filter(pool => getPoolCountry(pool) === selectedCountry && getPoolState(pool) === selectedState).map(getPoolCity)));
+
+  const filteredPools = POOLS.filter(pool => {
+    const matchesCountry = getPoolCountry(pool) === selectedCountry;
+    const matchesState = getPoolState(pool) === selectedState;
+    const matchesCity = selectedCity === 'All cities' || getPoolCity(pool) === selectedCity;
+    return matchesCountry && matchesState && matchesCity;
+  });
+
+  useEffect(() => {
+    if (!availableStates.includes(selectedState)) {
+      setSelectedState(availableStates[0] || '');
+    }
+  }, [selectedCountry]);
+
+  useEffect(() => {
+    if (!availableCities.includes(selectedCity)) {
+      setSelectedCity('All cities');
+    }
+  }, [selectedCountry, selectedState]);
 
   useEffect(() => {
     if (selectedPool && !filteredPools.some(pool => pool.id === selectedPool)) {
       setSelectedPool(null);
       setSelectedLane(null);
     }
-  }, [selectedRegion, selectedPool, filteredPools]);
+  }, [selectedCountry, selectedState, selectedCity, selectedPool, filteredPools]);
 
   const getPoolStatus = (poolId) => {
     const data = poolData[poolId];
@@ -1279,10 +1309,10 @@ export default function PoolBusynessTracker() {
             </div>
             <div>
               <h1 className="text-2xl font-bold">Pool Pulse</h1>
-              <p className="text-teal-100 text-xs font-medium">{selectedRegion}</p>
+              <p className="text-teal-100 text-xs font-medium">{`${selectedCountry} > ${selectedState} > ${selectedCity}`}</p>
             </div>
           </div>
-          <p className="text-teal-50 text-sm">Real-time lane busyness for pools in {selectedRegion}</p>
+          <p className="text-teal-50 text-sm">Real-time lane busyness for pools in {`${selectedCountry} > ${selectedState} > ${selectedCity}`}</p>
         </div>
       </div>
 
@@ -1294,23 +1324,21 @@ export default function PoolBusynessTracker() {
       )}
 
       <div className="max-w-2xl mx-auto px-4 py-6">
-        {/* Region Filter */}
-        <div className="mb-4">
-          <p className="text-sm font-semibold text-gray-700 mb-2">Filter by region</p>
-          <div className="grid grid-cols-2 gap-2 bg-white p-2 rounded-xl shadow-sm border border-gray-100">
-            {['Scotland', 'The Netherlands'].map(region => (
-              <button
-                key={region}
-                onClick={() => setSelectedRegion(region)}
-                className={`px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
-                  selectedRegion === region
-                    ? 'bg-teal-600 text-white shadow'
-                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                }`}
-              >
-                {region}
-              </button>
-            ))}
+        {/* Location Filter */}
+        <div className="mb-4 bg-white p-4 rounded-xl shadow-sm border border-gray-100">
+          <p className="text-sm font-semibold text-gray-700 mb-3">Filter by location (Country > State > City)</p>
+          <div className="grid md:grid-cols-3 gap-3">
+            <select value={selectedCountry} onChange={(e) => setSelectedCountry(e.target.value)} className="w-full px-3 py-2 border border-gray-200 rounded-lg">
+              <option value="UK">UK</option>
+              <option value="Netherlands">Netherlands</option>
+            </select>
+            <select value={selectedState} onChange={(e) => setSelectedState(e.target.value)} className="w-full px-3 py-2 border border-gray-200 rounded-lg">
+              {availableStates.map(state => <option key={state} value={state}>{state}</option>)}
+            </select>
+            <select value={selectedCity} onChange={(e) => setSelectedCity(e.target.value)} className="w-full px-3 py-2 border border-gray-200 rounded-lg">
+              <option value="All cities">All cities</option>
+              {availableCities.map(city => <option key={city} value={city}>{city}</option>)}
+            </select>
           </div>
         </div>
 
@@ -1467,7 +1495,7 @@ export default function PoolBusynessTracker() {
 
         {/* Info Footer */}
         <div className="mt-6 text-center text-gray-500 text-sm">
-          <p>Community-powered lane tracking for swimmers in Scotland and The Netherlands</p>
+          <p>Community-powered lane tracking for swimmers across UK and the Netherlands</p>
           <p className="mt-1">Check in when you arrive • See how many swimmers are in each lane</p>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Provide a hierarchical location filter so users can narrow pools by `Country > State > City` (e.g. `UK > England > London`) for both browsing and check-in flows. 
- Ensure the check-in pool picker is constrained to the same filtered pool set and the UI reflects the selected location path.

### Description
- Introduced new state variables `selectedCountry`, `selectedState`, and `selectedCity` and wired them into the component state model. 
- Added helper functions `getPoolCountry` and `getPoolState` plus derived lists `availableStates` and `availableCities` and implemented cascaded `filteredPools` logic that matches `Country`, `State`, and `City` selections. 
- Replaced the old region toggle with a three-column dropdown UI for Country/State/City and updated the header breadcrumb to show the selected hierarchy (`{selectedCountry} > {selectedState} > {selectedCity}`). 
- Ensured the check-in pool `<select>` and all selection validity checks use `filteredPools` so selected pool/lane state is reset when the location filter changes.

### Testing
- No automated tests were run because the project has no test script configured (`npm test` is not set up in `package.json`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0d084924832695f803763f9e3b8a)