### PR TITLE
Replace personal Gmail with hello@poolpulse.uk across site

### DIFF
--- a/index.html
+++ b/index.html
@@ -459,7 +459,7 @@ const LogoWordmark = ({ size = "lg" }) => {
       const [cityFilter, setCityFilter] = useState("All");
 
       // Feedback form
-      const FEEDBACK_EMAIL = "snehasindhu2109@gmail.com";
+      const FEEDBACK_EMAIL = "hello@poolpulse.uk";
       const [feedbackType, setFeedbackType] = useState("general");
       const [feedbackMessage, setFeedbackMessage] = useState("");
       const [feedbackContact, setFeedbackContact] = useState("");

--- a/pool-busyness-tracker.jsx
+++ b/pool-busyness-tracker.jsx
@@ -788,8 +788,8 @@ export default function PoolBusynessTracker() {
             <h2 className="text-xl font-bold text-gray-900 mb-3">Questions?</h2>
             <p className="text-gray-700 leading-relaxed">
               If you have any questions about privacy or how Pool Pulse works, email me at{' '}
-              <a href="mailto:snehasindhu2109@gmail.com" className="text-teal-600 hover:text-teal-700 underline">
-                snehasindhu2109@gmail.com
+              <a href="mailto:hello@poolpulse.uk" className="text-teal-600 hover:text-teal-700 underline">
+                hello@poolpulse.uk
               </a>
             </p>
           </div>
@@ -891,8 +891,8 @@ export default function PoolBusynessTracker() {
             <h2 className="text-xl font-bold text-gray-900 mb-3">Questions or Problems?</h2>
             <p className="text-gray-700 leading-relaxed">
               If something's not working right or you have questions, email me at{' '}
-              <a href="mailto:snehasindhu2109@gmail.com" className="text-teal-600 hover:text-teal-700 underline">
-                snehasindhu2109@gmail.com
+              <a href="mailto:hello@poolpulse.uk" className="text-teal-600 hover:text-teal-700 underline">
+                hello@poolpulse.uk
               </a>
               {'. '}
               I'll do my best to help!
@@ -1065,7 +1065,7 @@ export default function PoolBusynessTracker() {
             <p>🔒 Your check-ins are anonymous • No personal data collected • No accounts required</p>
             <p className="mt-2">
               Made with 💙 by Sneha for the Edinburgh swimming community • 
-              <a href="mailto:snehasindhu2109@gmail.com" className="text-teal-600 hover:text-teal-700 underline ml-1">
+              <a href="mailto:hello@poolpulse.uk" className="text-teal-600 hover:text-teal-700 underline ml-1">
                 Contact me
               </a>
             </p>


### PR DESCRIPTION
### Motivation
- Replace the personal Gmail address with the official project contact to centralize communications and align branding across the app.

### Description
- Updated `FEEDBACK_EMAIL` and all `mailto:` links from `snehasindhu2109@gmail.com` to `hello@poolpulse.uk` in `index.html` and `pool-busyness-tracker.jsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa11cdb7508326a0d5c83e957a53cd)