### PR TITLE
Add 'Suggest a pool' CTA below pool selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -2124,6 +2124,7 @@ useEffect(() => {
                     <option key={pool.id} value={pool.id}>{pool.name}</option>
                   ))}
                 </select>
+                <a href="mailto:hello@poolpulse.uk?subject=Pool%20suggestion%20%E2%80%94%20%5BPool%20name%5D%2C%20%5BCity%5D" className="mt-2 block text-center text-[0.85rem] text-gray-500 no-underline hover:underline">Don't see your pool? Suggest it →</a>
               </div>
 
               {selectedPool && !selectedPoolIsOpen && (


### PR DESCRIPTION
### Motivation
- Provide an easy way for users to suggest missing pools directly from the check-in UI without adding forms or JS.

### Description
- Added a single anchor line below the pool `<select>` in `index.html` that reads `Don't see your pool? Suggest it →` and uses a `mailto:` link with the requested subject.
- Styled the link to be small, subtle and secondary using Tailwind classes (`text-[0.85rem] text-gray-500 no-underline hover:underline mt-2 block text-center`) and did not modify any existing functionality or add JavaScript.

### Testing
- Ran `git diff --check` which reported no problems and passed.
- Executed a Python static assertion that verified the CTA anchor and exact `mailto:` href are present immediately after the pool selector, which succeeded.
- Attempted automated Playwright screenshot verification, but `npx playwright install chromium` failed due to the browser CDN returning `403 Forbidden`, so end-to-end visual verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b84d31348326ade8a415cb3b16da)